### PR TITLE
Examples ported to Johnny-Five

### DIFF
--- a/recipies/Johnny-Five Examples/basic-johnny-five.xdk
+++ b/recipies/Johnny-Five Examples/basic-johnny-five.xdk
@@ -1,0 +1,335 @@
+{
+  "project": {
+    "projectSettingsVersion": "1.1",
+    "creationData": {
+      "type": "Internet of Things Creator",
+      "projectTypeName": "com.intel.xdk.projecttype.iotapp",
+      "src": "https://edge-intel.s3.amazonaws.com/iotapp/production/release-2014-ww51/iotapp-local-temperature/sample.zip",
+      "projectGuid": "2926c5b8-8706-4644-a12d-a03b0147f696",
+      "lastModifiedDate": 1421433835825,
+      "creationDate": 1421433835788
+    },
+    "sourceDirectory": "",
+    "cordovaPluginsDirectory": "plugins",
+    "startFile": "main.js",
+    "projectFiles": {},
+    "projectDirectories": {},
+    "libraries": [
+      {
+        "name": "Cordova",
+        "version": "2.9.0",
+        "data": {
+          "default": true
+        }
+      },
+      {
+        "name": "intelXDK",
+        "version": "4.0.0",
+        "data": {
+          "default": true
+        }
+      }
+    ],
+    "cordovaPlugins": [
+      {
+        "id": "org.apache.cordova.device-motion",
+        "version": "0.2.4",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.camera",
+        "version": "0.2.9",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.media-capture",
+        "version": "0.2.8",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.device-orientation",
+        "version": "0.3.6",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.network-information",
+        "version": "0.2.8",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.contacts",
+        "version": "0.2.8",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.device",
+        "version": "0.2.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.battery-status",
+        "version": "0.2.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.file",
+        "version": "0.2.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.geolocation",
+        "version": "0.3.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.globalization",
+        "version": "0.2.7",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.inappbrowser",
+        "version": "0.3.0",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.media",
+        "version": "0.2.8",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.dialogs",
+        "version": "0.2.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.vibration",
+        "version": "0.3.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "org.apache.cordova.splashscreen",
+        "version": "0.2.5",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.accelerometer",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.audio",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.base",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.cache",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.camera",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.contacts",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.device",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.display",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.facebook",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.file",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.geolocation",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.notification",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      },
+      {
+        "id": "intel.xdk.player",
+        "selectedState": "Auto",
+        "data": {},
+        "paramvals": {}
+      }
+    ],
+    "serviceMethods": [],
+    "buildConfigurations": {
+      "Android": {
+        "platform_": "android",
+        "runtime_": "Cordova 3.x",
+        "name_": "Android",
+        "preferences_": {
+          "android-minSdkVersion": "10",
+          "android-targetSdkVersion": "19",
+          "android-installLocation": "auto"
+        },
+        "isActive_": true,
+        "appName_": "johnny-five",
+        "appID_": "not.yet.specified",
+        "appAccess_": "*",
+        "icons_": [],
+        "splashes_": [],
+        "iosProvs_": [],
+        "addlPermissions_": "",
+        "excludedLibraries_": "",
+        "cordovaCLIVersion_": "3.5",
+        "crosswalkVersion_": "stable",
+        "appVersion_": "1.0.0",
+        "appVersionCode_": "1"
+      },
+      "Android-Crosswalk": {
+        "platform_": "android",
+        "runtime_": "Crosswalk with Cordova 3.x",
+        "name_": "Android-Crosswalk",
+        "preferences_": {
+          "android-minSdkVersion": "14",
+          "android-targetSdkVersion": "19",
+          "android-installLocation": "auto"
+        },
+        "isActive_": true,
+        "appName_": "johnny-five",
+        "appID_": "not.yet.specified",
+        "appAccess_": "*",
+        "icons_": [],
+        "splashes_": [],
+        "iosProvs_": [],
+        "addlPermissions_": "",
+        "excludedLibraries_": "",
+        "cordovaCLIVersion_": "3.5",
+        "crosswalkVersion_": "stable",
+        "appVersion_": "1.0.0",
+        "appVersionCode_": "1"
+      },
+      "iOS": {
+        "platform_": "ios",
+        "runtime_": "Cordova 3.x",
+        "name_": "iOS",
+        "preferences_": {
+          "ios-target": "5",
+          "ios-configuration": "adhoc"
+        },
+        "isActive_": true,
+        "appName_": "johnny-five",
+        "appID_": "not.yet.specified",
+        "appAccess_": "*",
+        "icons_": [],
+        "splashes_": [],
+        "iosProvs_": [],
+        "addlPermissions_": "",
+        "excludedLibraries_": "",
+        "cordovaCLIVersion_": "3.5",
+        "crosswalkVersion_": "stable",
+        "appVersion_": "1.0.0"
+      },
+      "Windows8": {
+        "platform_": "windows8",
+        "runtime_": "Cordova 3.x",
+        "name_": "Windows8",
+        "preferences_": {},
+        "isActive_": true,
+        "appName_": "johnny-five",
+        "appID_": "not.yet.specified",
+        "appAccess_": "*",
+        "icons_": [],
+        "splashes_": [],
+        "iosProvs_": [],
+        "addlPermissions_": "",
+        "excludedLibraries_": "",
+        "cordovaCLIVersion_": "3.5",
+        "crosswalkVersion_": "stable",
+        "appVersion_": "1.0.0.0"
+      },
+      "WindowsPhone8": {
+        "platform_": "wp8",
+        "runtime_": "Cordova 3.x",
+        "name_": "WindowsPhone8",
+        "preferences_": {},
+        "isActive_": true,
+        "appName_": "johnny-five",
+        "appID_": "not.yet.specified",
+        "appAccess_": "*",
+        "icons_": [],
+        "splashes_": [],
+        "iosProvs_": [],
+        "addlPermissions_": "",
+        "excludedLibraries_": "",
+        "cordovaCLIVersion_": "3.5",
+        "crosswalkVersion_": "stable",
+        "appVersion_": "1.0.0.0"
+      }
+    },
+    "gameAssetDirectory": "asset",
+    "gameMetadata": {},
+    "projectTags": []
+  }
+}

--- a/recipies/Johnny-Five Examples/basic-johnny-five.xdke
+++ b/recipies/Johnny-Five Examples/basic-johnny-five.xdke
@@ -1,0 +1,7 @@
+{
+  "project": {
+    "projectSettingsVersion": "1.1",
+    "projectFiles": {},
+    "projectDirectories": {}
+  }
+}

--- a/recipies/Johnny-Five Examples/blink.js
+++ b/recipies/Johnny-Five Examples/blink.js
@@ -1,0 +1,12 @@
+// Blink an LED
+// Pin 13 is the default pin on the large Arduino breakout board, change as needed.
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var led = new five.Led(13);
+  led.blink(1000);
+});

--- a/recipies/Johnny-Five Examples/button.js
+++ b/recipies/Johnny-Five Examples/button.js
@@ -1,0 +1,21 @@
+// Activate the touch button
+// This code will work for BOTH the capactive button and the "standard" button with a black tip
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var touch = new five.Button(4);
+
+  touch.on("press", function() {
+    console.log("Pressed!");
+  });
+  touch.on("release", function() {
+    console.log("Released!");
+  });
+  touch.on("hold", function() {
+    console.log("Holding...");
+  });
+});

--- a/recipies/Johnny-Five Examples/buzzer.js
+++ b/recipies/Johnny-Five Examples/buzzer.js
@@ -1,0 +1,17 @@
+// Make the buzzer go beep
+// Warning - this is going to be really annoying.
+//
+// ----> npm install j5-songs <----
+//
+var songs = require("j5-songs");
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var buzzer = new five.Piezo(4);
+  var tetris = songs.load("tetris-theme");
+  buzzer.play(tetris);
+});

--- a/recipies/Johnny-Five Examples/lcd-screen.js
+++ b/recipies/Johnny-Five Examples/lcd-screen.js
@@ -1,0 +1,16 @@
+// How to write to the Seeed LCD Screen
+// NOTE: You *MUST* plug the LCD into an I2C slot or this will not work!
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var lcd = new five.LCD({
+    controller: "JHD1313M1"
+  });
+
+  lcd.useChar("heart");
+  lcd.cursor(0, 0).print("I :heart: Johnny-Five");
+});

--- a/recipies/Johnny-Five Examples/light.js
+++ b/recipies/Johnny-Five Examples/light.js
@@ -1,0 +1,15 @@
+// Plug the light sensor into the Analog port A0 on the provided
+// Seeed Sensor Kit Arduino Shield
+// MUST be in the analog pin slots!
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var light = new five.Sensor("A0");
+  this.loop(2000, function() {
+    console.log("Light sensor value: ", light.value);
+  });
+});

--- a/recipies/Johnny-Five Examples/package.json
+++ b/recipies/Johnny-Five Examples/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "edison-johnny-five",
+  "description": "A simple Edison blink sketch.",
+  "version": "0.0.1",
+  "main": "blink.js",
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+      "johnny-five": "latest",
+      "edison-io": "0.8.1"
+  }
+}

--- a/recipies/Johnny-Five Examples/relay.js
+++ b/recipies/Johnny-Five Examples/relay.js
@@ -1,0 +1,14 @@
+// Blink an LED
+// Pin 13 is the default pin on the large Arduino breakout board, change as needed.
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var relay = new five.Relay(4);
+  this.loop(1000, function() {
+    relay.toggle();
+  });
+});

--- a/recipies/Johnny-Five Examples/rotary.js
+++ b/recipies/Johnny-Five Examples/rotary.js
@@ -1,0 +1,13 @@
+// Rotary angle switch
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var rotary = new five.Sensor("A0");
+  rotary.on("data", function() {
+    console.log(this.value);
+  });
+});

--- a/recipies/Johnny-Five Examples/servo.js
+++ b/recipies/Johnny-Five Examples/servo.js
@@ -1,0 +1,15 @@
+// Servo Demo
+// This code will move the servo in several directions as proof of concept
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var servo = new five.Servo(3);
+  servo.sweep({
+    range: [45, 135],
+    interval: 1000
+  });
+});

--- a/recipies/Johnny-Five Examples/sound.js
+++ b/recipies/Johnny-Five Examples/sound.js
@@ -1,0 +1,21 @@
+// Plug the sound sensor into the Analog port A0 on the provided
+// Seeed Sensor Kit Arduino Shield
+// MUST be in the analog pin slots!
+// Plug the Led component into the D4 slot
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var sound = new five.Sensor("A0");
+  var led = new five.Led(4);
+
+  this.loop(1, function() {
+    if (sound.value > 400) {
+      led.on();
+    }
+    led.off();
+  });
+});

--- a/recipies/Johnny-Five Examples/temperature.js
+++ b/recipies/Johnny-Five Examples/temperature.js
@@ -1,0 +1,19 @@
+// Plug the temperature sensor into the Analog port A0 on the provided
+// Seeed Sensor Kit Arduino Shield
+// MUST be in the analog pin slots!
+var five = require("johnny-five");
+var Edison = require("edison-io");
+var board = new five.Board({
+  io: new Edison()
+});
+
+board.on("ready", function() {
+  var temp = new five.Temperature({
+    pin: "A0",
+    controller: "GROVE"
+  });
+
+  this.loop(2000, function() {
+    console.log("%d°C", Math.round(temp.celsius));
+  });
+});


### PR DESCRIPTION
Each of these has been tested and confirmed on:
- Intel Edison Arduino Board
- Intel Galileo Gen 2

Requires:
- Grove IoT Kit

Examples have "1-to-1" functional parity with their Cylon counterpart, with the following exceptions:
- Button: Demonstrates press, hold and release, instead of just press and release
- Buzzer: plays the Tetris theme song as defined in the "j5-songs" module, instead of just on/off.
- LCD Screen: Displays a message with an inline heart character which is stored in LCD memory.
- Sound: Uses an LED to display the detection of sounds over a threshold ADC value.
- Temperature: displays the temp in celcius, instead of a raw ADC value.

An alternate version of the wiki guide is available and will be moved to https://github.com/mashery/edison-guides/wiki/ once this patch lands.
- https://github.com/rwaldron/johnny-five/wiki/Johnny-Five-and-Intel-IoTDevKit-Example-Sketches draft
